### PR TITLE
Use PyTorch's header files

### DIFF
--- a/wind_rwkv/rwkv7/chunked_cuda/chunked_cuda.cpp
+++ b/wind_rwkv/rwkv7/chunked_cuda/chunked_cuda.cpp
@@ -1,7 +1,8 @@
 // Copyright (c) 2024, Johan Sokrates Wind
 
 #include <torch/extension.h>
-#include <cuda_bf16.h>
+
+struct __nv_bfloat16;
 using bf = __nv_bfloat16;
 using torch::Tensor;
 


### PR DESCRIPTION
Dear johanwind.

When I use your fantastic kernel, I found a strange problem. I can compile smallhead, However,chunked tells me:

```
    4 | #include <cuda_bf16.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
```

This PR use pytorch header file to solve this problem.

I use a new conda env and install pytorch\ cuda toolkit from new env.

